### PR TITLE
Remove activeadmin version upper limit from gemspec

### DIFF
--- a/activeadmin_blaze_theme.gemspec
+++ b/activeadmin_blaze_theme.gemspec
@@ -18,5 +18,5 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency 'activeadmin', '~> 1.0'
+  spec.add_runtime_dependency 'activeadmin', '>= 1.0.0'
 end


### PR DESCRIPTION
ActiveAdmin recently reached version 2.0.0.  The theme still works correctly with the new version but the dependency in gemspec is too strict.
This PR loosens the depenency limit.