### PR TITLE
Fix horizontal scroll bar being always visible in index as table

### DIFF
--- a/app/assets/stylesheets/activeadmin_blaze_theme/_tables.scss
+++ b/app/assets/stylesheets/activeadmin_blaze_theme/_tables.scss
@@ -74,7 +74,7 @@ body.active_admin {
     }
   }
   .index_as_table {
-    overflow-x: scroll;
+    overflow-x: auto;
   }
   .panel_contents table tr:last-child {
     > td, > th {


### PR DESCRIPTION
Hello!
I've found out that the horizontal scroll bar in index-as-table pages is always visible, even when content does not overflow (the element pointed out in the screenshot below is the scroll bar that gets rendered when there is no overflow).

<img width="1140" alt="scrollbar_overflow" src="https://user-images.githubusercontent.com/30041551/112800209-a5102380-906f-11eb-979a-59717a191fc6.png">

Setting `overflow-x` rule to `auto` in the CSS fixes the issue.