### PR TITLE
WIP: Move dependencies gems into dev and prod group

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,15 +4,17 @@ source 'https://rubygems.org'
 
 gemspec
 
-gem 'pry-rails'
+group :development, :test do
+  gem 'pry-rails'
 
-gem 'activestorage', '~> 6.0'
-gem 'capybara', '~> 3.33'
-gem 'puma', '~> 4.3'
-gem 'rspec-rails'
-gem 'rspec_junit_formatter', '~> 0.4'
-gem 'rubocop', '~> 1.0'
-gem 'sassc', '~> 2.4'
-gem 'selenium-webdriver', '~> 3.142'
-gem 'sprockets-rails', '~> 3.2'
-gem 'sqlite3', '~> 1.4'
+  gem 'activestorage', '~> 6.0'
+  gem 'capybara', '~> 3.33'
+  gem 'puma', '~> 4.3'
+  gem 'rspec-rails'
+  gem 'rspec_junit_formatter', '~> 0.4'
+  gem 'rubocop', '~> 1.0'
+  gem 'sassc', '~> 2.4'
+  gem 'selenium-webdriver', '~> 3.142'
+  gem 'sprockets-rails', '~> 3.2'
+  gem 'sqlite3', '~> 1.4'
+end

--- a/activeadmin_blaze_theme.gemspec
+++ b/activeadmin_blaze_theme.gemspec
@@ -20,4 +20,5 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_runtime_dependency 'activeadmin', '~> 2.0'
+  spec.add_runtime_dependency 'sassc', '~> 2.4'
 end


### PR DESCRIPTION
Adding gems directly in the gemfile instead of the gemspec have 2 impacts on a project that is using this gem: 
- it will require all gems to be installed, but `bundle install` will not install them (as bundle only use the "parent" gemfile. So if we are not using one of your dev gems we have weird bugs : 
`bundle install`
![image](https://user-images.githubusercontent.com/12391171/118035719-95a41b80-b339-11eb-8113-eef4272318ca.png)
`rails s`
![image](https://user-images.githubusercontent.com/12391171/118035757-a6ed2800-b339-11eb-87e5-f6dcc5b9b8e5.png)


- It will not ensure dependencies requirements are met between all used gem by the "parent" project