### PR TITLE
Update gemspec

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,21 +6,24 @@ gemspec
 
 group :development, :test do
   gem 'activestorage', '~> 6.0'
-  gem 'capybara', '~> 3.33'
   gem 'puma', '~> 4.3'
-  gem 'rspec_junit_formatter', '~> 0.4'
-  gem 'rspec-rails'
-  gem 'selenium-webdriver', '~> 3.142'
+  gem 'sassc', '~> 2.4'
   gem 'sprockets-rails', '~> 3.2'
   gem 'sqlite3', '~> 1.4'
 
+  # Testing
+  gem 'capybara', '~> 3.33'
+  gem 'rspec_junit_formatter', '~> 0.4'
+  gem 'rspec-rails', '~> 5.1'
+  gem 'selenium-webdriver', '~> 3.142'
+
   # Linters
-  gem 'fasterer'
-  gem 'rubocop'
-  gem 'rubocop-packaging'
-  gem 'rubocop-performance'
-  gem 'rubocop-rails'
-  gem 'rubocop-rspec'
+  gem 'fasterer', '~> 0.9'
+  gem 'rubocop', '~> 1.25'
+  gem 'rubocop-packaging', '~> 0.5'
+  gem 'rubocop-performance', '~> 1.13'
+  gem 'rubocop-rails', '~> 2.13'
+  gem 'rubocop-rspec', '~> 2.8'
 
   # Tools
   gem 'pry-rails'

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Active Admin Blaze Theme
-[![gem version](https://badge.fury.io/rb/activeadmin_blaze_theme.svg)](https://badge.fury.io/rb/activeadmin_blaze_theme) [![gem downloads](https://badgen.net/rubygems/dt/activeadmin_blaze_theme)](https://rubygems.org/gems/activeadmin_blaze_theme) [![linters](https://github.com/blocknotes/activeadmin_blaze_theme/actions/workflows/linters.yml/badge.svg)](https://github.com/blocknotes/activeadmin_blaze_theme/actions/workflows/linters.yml) [![specs](https://github.com/blocknotes/activeadmin_blaze_theme/actions/workflows/specs.yml/badge.svg)](https://github.com/blocknotes/activeadmin_blaze_theme/actions/workflows/specs.yml)
+[![gem version](https://badge.fury.io/rb/activeadmin_blaze_theme.svg)](https://badge.fury.io/rb/activeadmin_blaze_theme)
+[![gem downloads](https://badgen.net/rubygems/dt/activeadmin_blaze_theme)](https://rubygems.org/gems/activeadmin_blaze_theme)
+[![linters](https://github.com/blocknotes/activeadmin_blaze_theme/actions/workflows/linters.yml/badge.svg)](https://github.com/blocknotes/activeadmin_blaze_theme/actions/workflows/linters.yml)
+[![specs](https://github.com/blocknotes/activeadmin_blaze_theme/actions/workflows/specs.yml/badge.svg)](https://github.com/blocknotes/activeadmin_blaze_theme/actions/workflows/specs.yml)
 
 A theme for Active Admin based on [Blaze CSS](http://blazecss.com) 3.x
 
@@ -21,6 +24,7 @@ First, add to your Gemfile: `gem 'activeadmin_blaze_theme'` (and execute `bundle
 
 Then, if you installed Active Admin **without Webpacker** support (so using Sprockets):
 
+- Add a SASS/SCSS gem to your Gemfile (ex. `gem 'sassc'`)
 - Add at the end of your Active Admin styles (_app/assets/stylesheets/active_admin.scss_):
 
 ```scss

--- a/activeadmin_blaze_theme.gemspec
+++ b/activeadmin_blaze_theme.gemspec
@@ -16,6 +16,7 @@ Gem::Specification.new do |spec|
 
   spec.files         = Dir["{app,lib}/**/*", 'LICENSE.txt', 'README.md', 'index.js', 'package.json']
   spec.require_paths = ['lib']
+  spec.metadata      = { "rubygems_mfa_required" => "true" }
 
   spec.add_runtime_dependency 'activeadmin', '~> 2.0'
   spec.add_runtime_dependency 'sassc', '~> 2.4'

--- a/activeadmin_blaze_theme.gemspec
+++ b/activeadmin_blaze_theme.gemspec
@@ -19,5 +19,4 @@ Gem::Specification.new do |spec|
   spec.metadata      = { "rubygems_mfa_required" => "true" }
 
   spec.add_runtime_dependency 'activeadmin', '~> 2.0'
-  spec.add_runtime_dependency 'sassc', '~> 2.4'
 end


### PR DESCRIPTION
Remove Sassc runtime dependency => the SASS/SCSS library to use must be handled by the user application.

Closes #23 